### PR TITLE
Move CQL generation into main function and enable better error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ hubot wiki <term> - Search term to look up
 * HUBOT_CONFLUENCE_HOST - Confluence's base url (ie http://localhost:8080/confluence/)
 * HUBOT_CONFLUENCE_USERNAME - Confluence username
 * HUBOT_CONFLUENCE_PASSWORD - Confluence password
+* HUBOT_CONFLUENCE_SEARCH_SPACE - Specify to search within a single space only
 
 ## Release History
 

--- a/src/scripts/confluence.js
+++ b/src/scripts/confluence.js
@@ -6,7 +6,7 @@ var url = require('url');
 module.exports = function(username, password, hostname) {
   var uri = url.resolve(hostname, '/rest/api/content/search');
   return {
-    simpleSearch: function(str) {
+    simpleSearch: function(cql) {
       return new Promise(function(resolve, reject) {
         request({
           method: 'GET',
@@ -14,7 +14,7 @@ module.exports = function(username, password, hostname) {
           json: true,
           qs: {
             limit: 5,
-            cql: 'type = page and siteSearch ~ "' + str + '"'
+            cql : cql
           },
           auth: {
             'user': username,
@@ -25,7 +25,8 @@ module.exports = function(username, password, hostname) {
           if (err) { return reject(err); }
           //Check for right status code
           if(response.statusCode !== 200) {
-            return reject('Invalid Status Code Returned:' + response.statusCode);
+            var bod = JSON.stringify(response.body);
+            return reject('Invalid Status Code Returned: ' + response.statusCode + ' - ' + response.body.message);
           }
 
           if (!results) { return reject("empty result object"); }

--- a/src/scripts/hubot-confluence-search.js
+++ b/src/scripts/hubot-confluence-search.js
@@ -24,16 +24,25 @@ var url = require("url");
 
 var username = process.env.HUBOT_CONFLUENCE_USERNAME;
 var password = process.env.HUBOT_CONFLUENCE_PASSWORD;
+var space = process.env.HUBOT_CONFLUENCE_SEARCH_SPACE;
 var host = process.env.HUBOT_CONFLUENCE_HOST;
 
 var uri = url.resolve(host, '/rest/api/content/search');
 
 module.exports = function (robot) {
   robot.confluence_search = new require('./confluence.js')(username, password, host);
-
   //robot.parseHelp(__filename);
   robot.respond(/wiki\s*(.*)$/, function (res) {
-    robot.confluence_search.simpleSearch(res.match[1]).then(function(results) {
+
+    var query = ''
+    if (space) {
+      query = 'space = "' + space + '" and ';
+    }
+    query = query + 'text ~ "' + res.match[1] + '"';
+
+    console.log("Running confluence query: " + query);
+
+    robot.confluence_search.simpleSearch(query).then(function(results) {
       if (results.results.length === 0) {
         res.send( 'Nothing found' );
         return;

--- a/src/scripts/hubot-confluence-search.js
+++ b/src/scripts/hubot-confluence-search.js
@@ -8,6 +8,7 @@
 //   HUBOT_CONFLUENCE_HOST - Confluence's base url (ie http://localhost:8080/confluence/)
 //   HUBOT_CONFLUENCE_USERNAME - Confluence username
 //   HUBOT_CONFLUENCE_PASSWORD - password
+//   HUBOT_CONFLUENCE_SEARCH_SPACE - Specify to search within a single space only
 //
 // Commands:
 //   hubot wiki <term> - Search term to look up
@@ -39,8 +40,6 @@ module.exports = function (robot) {
       query = 'space = "' + space + '" and ';
     }
     query = query + 'text ~ "' + res.match[1] + '"';
-
-    console.log("Running confluence query: " + query);
 
     robot.confluence_search.simpleSearch(query).then(function(results) {
       if (results.results.length === 0) {


### PR DESCRIPTION
The CQL you were using didn't work on my confluence, so I had to make it a bit more generic.

I also wanted to search in just a single space (my organisation has many spaces) so I added that functionality too.

This moves the CQL generation into the main function so it can be extended easily later.
